### PR TITLE
Промена на инфо кутијата за прогресивен данок

### DIFF
--- a/src/Views.elm
+++ b/src/Views.elm
@@ -148,7 +148,7 @@ progressiveInfo model =
                 text ("Прогресивниот данок не влијае за плата со нето износ " ++ String.fromInt model.neto ++ " денар(и).")
 
             _ ->
-                text ("Со прогресивниот данок, новата нето плата е намалена за " ++ String.fromInt namaluvanje ++ "  денар(и).")
+                text ("Со прогресивната даночна реформа, се плаќаат дополнителни " ++ String.fromInt namaluvanje ++ " денар(и).")
         ]
 
 


### PR DESCRIPTION
Базирано на https://www.finance.gov.mk/mk/node/7596:
>  ...[за] доходот кој надминува 90.000 денари, би се плаќале дополнителни 8%.